### PR TITLE
add grunt-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-cli": "~0.1.11",
     "grunt-jasmine-bundle": "~0.1.4",
     "frisby": "~0.7.5",
     "nodemon": "~0.7.10",


### PR DESCRIPTION
I was setting this up on a laptop I don't normally use for node, and ran
into an error that more or less equates to bash throwing a "command not
found" for grunt. Adding grunt-cli makes sure npm installs the grunt
command line binaries.

/cc @tkaufman @theotherzach -- I won't be able to make the thing tomorrow (at least the beginning), but maybe this commit will save someone from getting a silly error off the start :) Hope it helps.
